### PR TITLE
Changes:

### DIFF
--- a/ConsoleLogReaderCSGO/LogReader.cs
+++ b/ConsoleLogReaderCSGO/LogReader.cs
@@ -102,8 +102,8 @@ namespace ConsoleLogReaderCSGO
         private IEnumerable<string> CheckTypeT(T logs)
         {
             return logs is IEnumerable<string> enumerable ? enumerable
-                : logs is string ? logs.ToString().Split(new char[] { '\r', '\n' }).Where(y => !string.IsNullOrEmpty(y)).ToArray()
-                : default(IEnumerable<string>);
+                : logs is string ? logs.ToString().Split(new char[] { '\r', '\n' }).Where(y => !string.IsNullOrEmpty(y))
+                : default;
         }
 
         private void UpdateLog(T logs, bool isExtendedFile)
@@ -112,7 +112,7 @@ namespace ConsoleLogReaderCSGO
 
             if (Value != null)
             {
-                (List<LogSorted>, int) response = isExtendedFile ? Operations.UpdateConsoleLogFile.UpdateLogExtendedFIle(Value, LastLogIndex)
+                (IEnumerable<LogSorted>, int) response = isExtendedFile ? Operations.UpdateConsoleLogFile.UpdateLogExtendedFile(Value, LastLogIndex)
                     : Operations.UpdateConsoleLogFile.UpdateLogNewFile(Value, LastLogIndex);
                 
                 Data.Variables.ConsoleLines.AddRange(response.Item1);

--- a/ConsoleLogReaderCSGO/Operations/ReadConsoleLogFile.cs
+++ b/ConsoleLogReaderCSGO/Operations/ReadConsoleLogFile.cs
@@ -19,7 +19,7 @@ namespace ConsoleLogReaderCSGO.Operations
             int counter = 0;
             if (logs != null)
             {
-                return ((LogSorted[])logs.Select(x => new LogSorted(x, SetFlagToLogLine.DetermineFlag(x), counter++)).ToArray(), logs.ToArray().Length);
+                return ((LogSorted[])logs.Select(x => new LogSorted(x, Flag.SetFlagToLogLine.DetermineFlag(x), counter++)).ToArray(), logs.ToArray().Length);
             }
             return (null, 0);
             

--- a/ConsoleLogReaderCSGO/Operations/UpdateConsoleLogFile.cs
+++ b/ConsoleLogReaderCSGO/Operations/UpdateConsoleLogFile.cs
@@ -12,29 +12,29 @@ namespace ConsoleLogReaderCSGO.Operations
         #region Update methods
         /// <summary>
         /// <br>Method that take logs and index. It gets logs starting from provided index.</br>
-        /// <br>Returns Tuple of array of SortLogs and length of this array.</br>
+        /// <br>Returns Tuple of IEnumerable of SortLogs and length of this array.</br>
         /// <br>Index is index of last line on previous logs.</br>
         /// </summary>
         /// <param name="logs"></param>
         /// <param name="startIndex"></param>
         /// <returns></returns>
-        internal static (List<LogSorted>, int) UpdateLogExtendedFIle(IEnumerable<string> logs, int startIndex)
+        internal static (IEnumerable<LogSorted>, int) UpdateLogExtendedFile(IEnumerable<string> logs, int startIndex)
         {
             int counter = startIndex;
-            return (logs.Select((Value, Index) => new { Value, Index }).Where(x => x.Index >= startIndex).Select(x => new LogSorted(x.Value, SetFlagToLogLine.DetermineFlag(x.Value), counter++)).ToList(), logs.Count());
+            return (logs.Select((Value, Index) => new { Value, Index }).Where(x => x.Index >= startIndex).Select(x => new LogSorted(x.Value, SetFlagToLogLine.DetermineFlag(x.Value), counter++)), logs.Count());
         }
 
         /// <summary>
         /// <br>Method that take logs and index. It gets all logs.</br>
-        /// <br>Returns Tuple of array of SortLogs and length of this array.</br>
+        /// <br>Returns Tuple of IEnumerable of SortLogs and length of this array.</br>
         /// <br>Index is index of last line on previous logs.</br>
         /// </summary>
         /// <param name="logs"></param>
         /// <param name="startIndex"></param>
         /// <returns></returns>
-        internal static (List<LogSorted>, int) UpdateLogNewFile(IEnumerable<string> logs, int startIndex)
+        internal static (IEnumerable<LogSorted>, int) UpdateLogNewFile(IEnumerable<string> logs, int startIndex)
         {
-            return (logs.Select(x => new LogSorted(x, SetFlagToLogLine.DetermineFlag(x), startIndex++)).ToList(), logs.Count());
+            return (logs.Select(x => new LogSorted(x, SetFlagToLogLine.DetermineFlag(x), startIndex++)), logs.Count());
         }
 
         #endregion


### PR DESCRIPTION
Class UpdateConsoleLogFile:
• Replaced return parameter from List to IEnumerable in all methods. (and comments).
Class LogReader:
• Method UpdateLog fixed a typo and replace local variable from List to IEnumerable.
• Method CheckType simplified a default expresion and simplified if/else statement.
Class ReadConsoleLogFile:
• Method ReadConsoleFile added missed reference to DetermineFlag() method.